### PR TITLE
Autodetect path to lxd daemon lxd socket

### DIFF
--- a/examples/instances.rs
+++ b/examples/instances.rs
@@ -1,9 +1,9 @@
 /// Example of listing instances.
 /// Requires a local LXD running.
-use nlxd::client::Client;
+use nlxd::client::{Client, ClientConfig};
 
 fn main() {
-    let client = Client::new(Default::default()).unwrap();
+    let client = Client::new(ClientConfig::default_autodetect_local().unwrap()).unwrap();
     let instance_names: Vec<String> = client.instances().unwrap();
     println!("{:#?}", &instance_names);
     for name in instance_names {

--- a/examples/instances.rs
+++ b/examples/instances.rs
@@ -3,7 +3,7 @@
 use nlxd::client::{Client, ClientConfig};
 
 fn main() {
-    let client = Client::new(ClientConfig::default_autodetect_local().unwrap()).unwrap();
+    let client = Client::new(ClientConfig::default_with_detect_local().unwrap()).unwrap();
     let instance_names: Vec<String> = client.instances().unwrap();
     println!("{:#?}", &instance_names);
     for name in instance_names {

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,12 +51,12 @@ impl Endpoint {
     /// 4. otherwise fall back to `/var/lib/lxd/unix.socket` (lxd package)
     ///
     /// Return an error if invalid UTF8 is encountered when reading environment variables.
-    pub fn autodetect_local() -> Result<Self> {
+    pub fn detect_local() -> Result<Self> {
         fn try_get_env_var(name: &str) -> Result<Option<String>> {
             match env::var(name) {
                 Err(env::VarError::NotPresent) => Ok(None),
-                Err(x) => Err(x.into()),
-                Ok(s) => Ok(Some(s)),
+                Err(e) => Err(e.into()),
+                Ok(x) => Ok(Some(x)),
             }
         }
 
@@ -150,9 +150,9 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
-    pub fn default_autodetect_local() -> Result<Self> {
+    pub fn default_with_detect_local() -> Result<Self> {
         Ok(Self {
-            endpoint: Endpoint::autodetect_local()?,
+            endpoint: Endpoint::detect_local()?,
             version: LxdAPIVersion::default(),
             verify: true,
             timeout: Timeout::default(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -30,4 +31,7 @@ enum ErrorImpl {
 
     #[error("isahc web client error")]
     IsahcError(#[from] isahc::Error),
+
+    #[error("environment variable error")]
+    EnvVar(#[from] env::VarError),
 }


### PR DESCRIPTION
I designed the logic by inspiration from pylxd:

https://github.com/canonical/pylxd/blob/4d4b45014d708c8097f79c2dc896116fff1fe0fa/pylxd/client.py#L393-L400

and lxd cli:

https://github.com/canonical/lxd/blob/854006f80fb9a6d5d5c42900a4352f3d0381bc13/client/connection.go#L188-L199

Fixes: #8 